### PR TITLE
Update nfpm to patched fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,18 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 
 # Build templater
-WORKDIR "/go/src/github.com/hashicorp/crt-core-helloworld"
+WORKDIR "/go/src/github.com/hashicorp/actions-packaging-linux"
 COPY ./ .
 RUN go build -o nfpm_template
 RUN cp nfpm_template /usr/local/bin/nfpm_template
 RUN chmod +x /usr/local/bin/nfpm_template
 
 # Download nfpm
-RUN curl -Lo nfpm.tar.gz https://github.com/goreleaser/nfpm/releases/download/v2.13.0/nfpm_2.13.0_Linux_x86_64.tar.gz \
-    && tar -xf nfpm.tar.gz \
+# RUN curl -Lo nfpm.tar.gz https://github.com/goreleaser/nfpm/releases/download/v2.13.0/nfpm_2.13.0_Linux_x86_64.tar.gz \
+#     && tar -xf nfpm.tar.gz \
+RUN git clone --depth=1 --branch fix_deb_version_control https://github.com/kpenfound/nfpm.git \
+    && cd nfpm \
+    && go build ./cmd/nfpm \
     && cp nfpm /usr/local/bin/nfpm
 RUN chmod +x /usr/local/bin/nfpm
 


### PR DESCRIPTION
[JIRA](https://hashicorp.atlassian.net/browse/RELTOOL-138?atlOrigin=eyJpIjoiMTBmZjcyYjNiNjA5NDhlMjg2OTg3ODYyYWRjNzQxMGIiLCJwIjoiaiJ9)

This updates the nfpm version we're using to the patched version with corrected debian control files

Once there is a nfpm release including this fix, we'll go back to the official release