### PR TITLE
make binary path optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
   binary:
     description: 'Binary location to package.'
     default: ''
-    required: true
+    required: false
   config_dir:
     description: 'Directory of configs in desired filesystem structure.'
     default: ''

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -142,8 +142,10 @@ depends:
 {{- end }}
 {{- end }}
 contents:
+{{ if .Binary }}
   - src: {{ .Binary }}
     dst: /usr/bin/{{ .BinaryName }}
+{{ end }}
 {{- with .ConfigFiles }}
 {{- range $index, $element := . }}
   - src: {{ .LocalPath }}


### PR DESCRIPTION
Hi there,

this neat repo would be good to package [nomad-driver-podman](https://github.com/hashicorp/nomad-driver-podman) too.
nomad-driver-podman however is a plugin instead of a binary and it would be placed in /opt/nomad/plugins afaik.
so lifting the requirement of having a binary, would be a simple solution.

feel free to comment and or close if there's a better way

greetings