### PR TITLE
Add release instructions to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,16 @@ This is a GitHub Action wrapper around nFPM, used to produce DEBs and RPMs.
 | `postinstall` | Postinstall script location. | |
 | `preremove`   | Preremove script location. | |
 | `postremove`  | Postremove script location. | |
+
+## Release Instructions
+
+A new release has two parts: git tags, and a GitHub release.  Look at the
+current tags to determine what the next version should be.  In the instructions
+below, replace `v1` with `vN` where N is the major version of the new release
+if it's not `1`.
+
+1. `git checkout main && git pull origin main`
+1. `git tag v<new-version-number> && git push origin v<new-version-number>`
+1. Push the tag while you're on the `main` branch
+1. `git tag -d v1 && git push origin :refs/tags/v1`
+1. `git tag v1 && git push origin v1`


### PR DESCRIPTION
These instructions are copied from the [action-setup-bob docs](https://github.com/hashicorp/action-setup-bob#release-instructions), as the process is the same.