### PR TITLE
set default values for maintainer and vendor to hashicorp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This is a GitHub Action wrapper around nFPM, used to produce DEBs and RPMs.
 | `arch`       | Build architecture.                      |                |
 | `version`    | Product semver version. |  |
 | `maintainer` | Maintainer name. | |
+| `vendor`     | Default vendor. | HashiCorp |
 | `description` | Product description. | |
 | `homepage`    | Product homepage. | |
 | `license`     | Product usage license. | |

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
   vendor:
     description: 'Vendor name'
-    default: ''
+    default: 'HashiCorp'
     required: false
   description:
     description: 'Product description.'

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: 'Maintainer name.'
     default: ''
     required: false
+  vendor:
+    description: 'Vendor name'
+    default: ''
+    required: false
   description:
     description: 'Product description.'
     default: ''

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -76,6 +76,8 @@ func main() {
 	inputName := os.Getenv("INPUT_NAME")
 	inputArch := os.Getenv("INPUT_ARCH")
 	inputVersion := os.Getenv("INPUT_VERSION")
+	inputMaintainer := os.Getenv("INPUT_MAINTAINER")
+	inputVendor := os.Getenv("INPUT_VENDOR")
 	inputDescription := os.Getenv("INPUT_DESCRIPTION")
 	inputHomepage := os.Getenv("INPUT_HOMEPAGE")
 	inputLicense := os.Getenv("INPUT_LICENSE")
@@ -95,15 +97,6 @@ func main() {
 	binName := filepath.Base(inputBinary)
 	binDest := filepath.Join(inputBinPath, binName)
 
-	inputVendor := os.Getenv("INPUT_VENDOR")
-	if inputVendor == "" {
-		inputVendor = "HashiCorp"
-	}
-
-	inputMaintainer := os.Getenv("INPUT_MAINTAINER")
-	if inputVendor == "" {
-		inputVendor = "HashiCorp"
-	}
 	// This maps to "armv7hl" for rpm and "armhf" for deb
 	// "arm" is not a valid arch for either type, and it
 	// does not get mapped automatically in nfpm

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -15,6 +15,7 @@ type NfpmInput struct {
 	Arch        string
 	Version     string
 	Maintainer  string
+	Vendor      string
 	Description string
 	Homepage    string
 	License     string
@@ -76,6 +77,7 @@ func main() {
 	inputArch := os.Getenv("INPUT_ARCH")
 	inputVersion := os.Getenv("INPUT_VERSION")
 	inputMaintainer := os.Getenv("INPUT_MAINTAINER")
+	inputVendor := os.Getenv("INPUT_VENDOR")
 	inputDescription := os.Getenv("INPUT_DESCRIPTION")
 	inputHomepage := os.Getenv("INPUT_HOMEPAGE")
 	inputLicense := os.Getenv("INPUT_LICENSE")
@@ -110,6 +112,7 @@ func main() {
 		Arch:        inputArch,
 		Version:     inputVersion,
 		Maintainer:  inputMaintainer,
+		Vendor:      inputVendor,
 		Description: inputDescription,
 		Homepage:    inputHomepage,
 		License:     inputLicense,
@@ -136,7 +139,8 @@ arch: {{ .Arch }}
 platform: linux
 release: 1
 version: {{ .Version }}
-maintainer: {{ .Maintainer }}
+maintainer: "HashiCorp"
+vendor: "HashiCorp"
 description: {{ .Description }}
 homepage: {{ .Homepage }}
 license: {{ .License }}

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -76,8 +76,6 @@ func main() {
 	inputName := os.Getenv("INPUT_NAME")
 	inputArch := os.Getenv("INPUT_ARCH")
 	inputVersion := os.Getenv("INPUT_VERSION")
-	inputMaintainer := os.Getenv("INPUT_MAINTAINER")
-	inputVendor := os.Getenv("INPUT_VENDOR")
 	inputDescription := os.Getenv("INPUT_DESCRIPTION")
 	inputHomepage := os.Getenv("INPUT_HOMEPAGE")
 	inputLicense := os.Getenv("INPUT_LICENSE")
@@ -97,6 +95,15 @@ func main() {
 	binName := filepath.Base(inputBinary)
 	binDest := filepath.Join(inputBinPath, binName)
 
+	inputVendor := os.Getenv("INPUT_VENDOR")
+	if inputVendor == "" {
+		inputVendor = "HashiCorp"
+	}
+
+	inputMaintainer := os.Getenv("INPUT_MAINTAINER")
+	if inputVendor == "" {
+		inputVendor = "HashiCorp"
+	}
 	// This maps to "armv7hl" for rpm and "armhf" for deb
 	// "arm" is not a valid arch for either type, and it
 	// does not get mapped automatically in nfpm
@@ -139,8 +146,8 @@ arch: {{ .Arch }}
 platform: linux
 release: 1
 version: {{ .Version }}
-maintainer: "HashiCorp"
-vendor: "HashiCorp"
+maintainer: {{ .Maintainer}}
+vendor: {{ .Vendor }}
 description: {{ .Description }}
 homepage: {{ .Homepage }}
 license: {{ .License }}


### PR DESCRIPTION
Set `maintainer ` and `vendor` to HashiCorp to be able to show that HashiCorp is the maintainer/vendor of our linux packages. 