### PR TITLE
Update codeowners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,1 @@
-# These owners will be the default owners for everything in
-# the repo, unless a later match takes precedence. 
-
-* @hashicorp/release-engineering
-
+@hashicorp/team-selfmanaged-releng

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -2,14 +2,11 @@
 # SPDX-License-Identifier: MPL-2.0
 
 schema: 1.1
-
-partition: internal-platform
+partition: release-engineering
 category: github-action
-
 summary:
   name: actions-packaging-linux
-  owner: team-rel-eng
+  owner: team-selfmanaged-releng
   description: Builds linux packages (DEB's and RPM's). Meant for use in repos that have been onboarded to Common Release Tooling (CRT).
-  
   visibility: external
   auth_methods: none

--- a/META.d/data.yaml
+++ b/META.d/data.yaml
@@ -1,0 +1,3 @@
+_summary:
+  gdpr:
+    exempt: true

--- a/META.d/tags.yaml
+++ b/META.d/tags.yaml
@@ -6,4 +6,3 @@ tags:
   type: github-action
   crt-compatible: true
   exempt: tool-roam-config
-


### PR DESCRIPTION
Update CODEOWNERS for SMRE

This facilitates GH automatically selecting appropriate PR reviewers
and team discovery through Heimdall.

[skip ci]