### PR TITLE
Packages support file permissions and ownership

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,16 @@ jobs:
           license: MPL-2.0
           binary: ${{ steps.build.outputs.binary-path }}
           bin_path: /usr/local/bin
+          file_permissions: 0o027
+
+      - name: dump RPM
+        run: |
+          echo "::group::maybe install rpm" 1>&2
+          # runner is ubuntu, install rpm if it's not already available
+          which rpm || apt install -y rpm
+          echo "::endgroup::" 1>&2
+          rpm -qplv out/*.rpm
+
+      - name: dump deb
+        run: |
+          dpkg -c out/*.deb

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
           binary: ${{ steps.build.outputs.binary-path }}
           bin_path: /usr/local/bin
           file_permissions: 0o027
+          user_owner: root
+          group_owner: vault
 
       - name: dump RPM
         run: |

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,14 @@ inputs:
     description: 'File permissions applied to all files in the package; specify in yaml/octal format: `0o022`; if empty, permissions are unmodified.'
     default: ''
     required: false
+  user_owner:
+    description: 'The user name or ID that should own the files in the package; e.g.: root'
+    default: ''
+    required: false
+  group_owner:
+    description: 'The group name or ID that should own the files in the package; e.g.: root'
+    default: ''
+    required: false
   config_dir:
     description: 'Directory of configs in desired filesystem structure.'
     default: ''
@@ -182,6 +190,8 @@ runs:
         INPUT_BINARY: ${{ inputs.binary }}
         INPUT_BIN_PATH: ${{ inputs.bin_path }}
         INPUT_FILEPERMISSIONS: ${{ inputs.file_permissions }}
+        INPUT_USEROWNER: ${{ inputs.user_owner }}
+        INPUT_GROUPOWNER: ${{ inputs.group_owner }}
         INPUT_CONFIG_DIR: ${{ inputs.config_dir }}
         INPUT_PREINSTALL: ${{ inputs.preinstall }}
         INPUT_POSTINSTALL: ${{ inputs.postinstall }}

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,10 @@ inputs:
     description: 'Path to install the binary at'
     default: '/usr/bin'
     required: false
+  file_permissions:
+    description: 'File permissions applied to all files in the package; specify in yaml/octal format: `0o022`; if empty, permissions are unmodified.'
+    default: ''
+    required: false
   config_dir:
     description: 'Directory of configs in desired filesystem structure.'
     default: ''
@@ -177,6 +181,7 @@ runs:
         INPUT_DEPENDS: ${{ inputs.depends }}
         INPUT_BINARY: ${{ inputs.binary }}
         INPUT_BIN_PATH: ${{ inputs.bin_path }}
+        INPUT_FILEPERMISSIONS: ${{ inputs.file_permissions }}
         INPUT_CONFIG_DIR: ${{ inputs.config_dir }}
         INPUT_PREINSTALL: ${{ inputs.preinstall }}
         INPUT_POSTINSTALL: ${{ inputs.postinstall }}

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -27,6 +27,8 @@ type NfpmInput struct {
 	Postinstall     string
 	Preremove       string
 	Postremove      string
+	UserOwner       string
+	GroupOwner      string
 	FilePermissions string
 
 	ConfigFiles []*ConfigFile
@@ -92,6 +94,8 @@ func main() {
 	inputPreremove := os.Getenv("INPUT_PREREMOVE")
 	inputPostremove := os.Getenv("INPUT_POSTREMOVE")
 	inputPermissions := os.Getenv("INPUT_FILEPERMISSIONS")
+	inputUserOwner := os.Getenv("INPUT_USEROWNER")
+	inputGroupOwner := os.Getenv("INPUT_GROUPOWNER")
 
 	depends := strings.Split(inputDepends, ",")
 	if inputDepends == "" {
@@ -127,6 +131,8 @@ func main() {
 		Preremove:       inputPreremove,
 		Postremove:      inputPostremove,
 		FilePermissions: inputPermissions,
+		UserOwner:       inputUserOwner,
+		GroupOwner:      inputGroupOwner,
 	}
 
 	input.ConfigFiles = findConfigs(inputConfigDir)
@@ -163,12 +169,33 @@ contents:
 {{- if ne .Binary "" }}
   - src: {{ .Binary }}
     dst: {{ .BinaryDest }}
+{{- if or (ne .UserOwner "") (ne .GroupOwner "") }}
+    file_info:
+{{- if ne .UserOwner "" }}
+      owner: root
 {{- end }}
+{{- if ne .GroupOwner "" }}
+      group: vault
+{{- end }}
+{{- end }}
+{{- end }}
+{{- /* capture ownership for use in .ConfigFiles subcontext */ -}}
+{{- $userOwner := .UserOwner }}
+{{- $groupOwner := .GroupOwner }}
 {{- with .ConfigFiles }}
 {{- range $index, $element := . }}
   - src: {{ .LocalPath }}
     dst: {{ .DestPath }}
     type: config|noreplace
+{{- if or (ne $userOwner "") (ne $groupOwner "") }}
+    file_info:
+{{- if ne $userOwner "" }}
+      owner: root
+{{- end }}
+{{- if ne $groupOwner "" }}
+      group: vault
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 scripts:

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -12,21 +12,22 @@ import (
 )
 
 type NfpmInput struct {
-	Name        string
-	Arch        string
-	Version     string
-	Maintainer  string
-	Vendor      string
-	Description string
-	Homepage    string
-	License     string
-	Depends     []string
-	Binary      string
-	BinaryDest  string
-	Preinstall  string
-	Postinstall string
-	Preremove   string
-	Postremove  string
+	Name            string
+	Arch            string
+	Version         string
+	Maintainer      string
+	Vendor          string
+	Description     string
+	Homepage        string
+	License         string
+	Depends         []string
+	Binary          string
+	BinaryDest      string
+	Preinstall      string
+	Postinstall     string
+	Preremove       string
+	Postremove      string
+	FilePermissions string
 
 	ConfigFiles []*ConfigFile
 }
@@ -90,6 +91,7 @@ func main() {
 	inputPostinstall := os.Getenv("INPUT_POSTINSTALL")
 	inputPreremove := os.Getenv("INPUT_PREREMOVE")
 	inputPostremove := os.Getenv("INPUT_POSTREMOVE")
+	inputPermissions := os.Getenv("INPUT_FILEPERMISSIONS")
 
 	depends := strings.Split(inputDepends, ",")
 	if inputDepends == "" {
@@ -109,21 +111,22 @@ func main() {
 	}
 
 	input := &NfpmInput{
-		Name:        inputName,
-		Arch:        inputArch,
-		Version:     inputVersion,
-		Maintainer:  inputMaintainer,
-		Vendor:      inputVendor,
-		Description: inputDescription,
-		Homepage:    inputHomepage,
-		License:     inputLicense,
-		Depends:     depends,
-		Binary:      inputBinary,
-		BinaryDest:  binDest,
-		Preinstall:  inputPreinstall,
-		Postinstall: inputPostinstall,
-		Preremove:   inputPreremove,
-		Postremove:  inputPostremove,
+		Name:            inputName,
+		Arch:            inputArch,
+		Version:         inputVersion,
+		Maintainer:      inputMaintainer,
+		Vendor:          inputVendor,
+		Description:     inputDescription,
+		Homepage:        inputHomepage,
+		License:         inputLicense,
+		Depends:         depends,
+		Binary:          inputBinary,
+		BinaryDest:      binDest,
+		Preinstall:      inputPreinstall,
+		Postinstall:     inputPostinstall,
+		Preremove:       inputPreremove,
+		Postremove:      inputPostremove,
+		FilePermissions: inputPermissions,
 	}
 
 	input.ConfigFiles = findConfigs(inputConfigDir)
@@ -152,6 +155,9 @@ depends:
 {{- range $index, $element := . }}
   - {{ . }}
 {{- end }}
+{{- end }}
+{{- if ne .FilePermissions "" }}
+umask: {{ .FilePermissions }}
 {{- end }}
 contents:
 {{- if ne .Binary "" }}


### PR DESCRIPTION
In support of [SMRE-216](https://hashicorp.atlassian.net/browse/SMRE-216), this PR adds inputs to the action so product teams can specify file ownership and permissions for the contents of the generated packages.  These are global settings that apply to all files within the package, finer granularity is not supported at this time.

Self-test package results:
* [RPM](https://github.com/hashicorp/actions-packaging-linux/actions/runs/9468811130/job/26086022581#step:7:12)
* [Deb](https://github.com/hashicorp/actions-packaging-linux/actions/runs/9468811130/job/26086022581#step:8:8)

Note:  while this PR fixes ownership and permissions validation failures for RPM packages, it does not address Linux Capabilities (`P` flag in outputs below).  It appears nfpm is not capable of setting these values at this time.

Sample verification outputs:
EL7:
```bash
# rpm -vV vault-enterprise
.........  c /etc/vault.d/vault.env
.........  c /etc/vault.d/vault.hcl
........P    /usr/bin/vault
.........  c /usr/lib/systemd/system/vault.service
```

fedora-40:
```bash
# rpm -vV vault-enterprise
.........  c /etc/vault.d/vault.env
.........  c /etc/vault.d/vault.hcl
........P    /usr/bin/vault
.........  c /usr/lib/systemd/system/vault.service
```

[SMRE-216]: https://hashicorp.atlassian.net/browse/SMRE-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ