### PR TITLE
SMRE-396: support specifying recommended packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,15 +45,48 @@ jobs:
           file_permissions: 0o027
           user_owner: root
           group_owner: vault
+          rpm_depends: bash
+          rpm_recommends: dmidecode
+          deb_depends: bash
+          deb_recommends: dmidecode
 
+      - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        if: matrix.go_toolchain_preinstalled == true # only need one set of artifacts
+        with:
+          name: artifacts
+          path: out
+          if-no-files-found: 'error'
+
+      # Note: "suggested" is always empty, as nFPM does not (yet?) support it.
       - name: dump RPM
         run: |
+          /bin/ls -l out/
           echo "::group::maybe install rpm" 1>&2
           # runner is ubuntu, install rpm if it's not already available
-          which rpm || apt install -y rpm
+          which rpm || apt-get install -y rpm
           echo "::endgroup::" 1>&2
+
+          echo "::group::package contents" 1>&2
           rpm -qplv out/*.rpm
+          echo "::endgroup::" 1>&2
+
+          echo "::group::dependencies" 1>&2
+          rpm -qpv --requires out/*.rpm
+          echo "::endgroup::" 1>&2
+          echo "::group::weak dependencies: recommended packages" 1>&2
+          rpm -qpv --recommends out/*.rpm
+          echo "::endgroup::" 1>&2
+          echo "::group::weak dependencies: suggested packages" 1>&2
+          rpm -qpv --suggests out/*.rpm
+          echo "::endgroup::" 1>&2
 
       - name: dump deb
         run: |
-          dpkg -c out/*.deb
+          /bin/ls -l out/
+          echo "::group::package contents" 1>&2
+          dpkg -c ./out/*.deb
+          echo "::endgroup::" 1>&2
+
+          echo "::group::dependencies and recommended packages" 1>&2
+          apt-cache show ./out/*.deb | grep -E '^(Depends|Recommends|Suggests):' || true
+          echo "::endgroup::" 1>&2

--- a/action.yml
+++ b/action.yml
@@ -127,11 +127,13 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        NFPM_DEST: ${{ inputs.nfpm_destination }}
+        NFPM_VERSION: ${{ inputs.nfpm_version }}
       run: |
-        VERSION=$(gh release list -R goreleaser/nfpm --exclude-drafts --exclude-pre-releases | grep ${{ inputs.nfpm_version }} | cut -f1)
+        VERSION=$(gh release list -R goreleaser/nfpm --exclude-drafts --exclude-pre-releases | grep "$NFPM_VERSION" | cut -f1)
 
-        mkdir -p "$(dirname "${{ inputs.nfpm_destination }}")"
-        DESTINATION="$(readlink -f ${{ inputs.nfpm_destination }})"
+        mkdir -p "$(dirname "$NFPM_DEST")"
+        DESTINATION="$(readlink -f $NFPM_DEST)"
         DESTINATION_DIR="$(dirname "$DESTINATION")"
         echo "$DESTINATION_DIR" >> "$GITHUB_PATH"
 
@@ -187,9 +189,11 @@ runs:
     - name: Build nfpm_template binary
       shell: bash
       working-directory: nfpm_packaging
+      env:
+        TPL_DEST: ${{ inputs.nfpm_template_destination }}
       run: |
-        mkdir -p "$(dirname "${{ inputs.nfpm_template_destination }}")"
-        DESTINATION="$(readlink -f ${{ inputs.nfpm_template_destination }})"
+        mkdir -p "$(dirname "$TPL_DEST")"
+        DESTINATION="$(readlink -f $TPL_DEST)"
         DESTINATION_DIR="$(dirname "$DESTINATION")"
         echo "$DESTINATION_DIR" >> "$GITHUB_PATH"
         go build -o nfpm_template .
@@ -217,8 +221,11 @@ runs:
         INPUT_POSTINSTALL: ${{ inputs.postinstall }}
         INPUT_PREREMOVE: ${{ inputs.preremove }}
         INPUT_POSTREMOVE: ${{ inputs.postremove }}
+
+        INPUT_DEB_DEPENDS: ${{ inputs.deb_depends }}
+        INPUT_RPM_DEPENDS: ${{ inputs.rpm_depends }}
       run: |
-        if ! fileo=$(file "${{ inputs.binary }}"); then
+        if ! fileo=$(file "$INPUT_BINARY"); then
           printf "could not find binary: $(pwd)\n$(ls)"
           exit 1
         else
@@ -238,5 +245,5 @@ runs:
           nfpm package -f "$config_file" -p ${1} -t ./out/
         }
 
-        package rpm "${{ inputs.rpm_depends }}"
-        package deb "${{ inputs.deb_depends }}"
+        package rpm "$INPUT_RPM_DEPENDS"
+        package deb "$INPUT_DEB_DEPENDS"

--- a/action.yml
+++ b/action.yml
@@ -255,5 +255,5 @@ runs:
           nfpm package -f "$config_file" -p "$pkg_type" -t ./out/
         }
 
-        package rpm "$INPUT_RPM_DEPENDS"
-        package deb "$INPUT_DEB_DEPENDS"
+        package rpm "$INPUT_RPM_DEPENDS" "$INPUT_RPM_RECOMMENDS"
+        package deb "$INPUT_DEB_DEPENDS" "$INPUT_DEB_RECOMMENDS"

--- a/action.yml
+++ b/action.yml
@@ -234,15 +234,15 @@ runs:
 
         mkdir -p ./out
 
-        package() {
+        package() { local pkg_type="$1" deps="${2:-}"
           local config_file
-          config_file="nfpm_${1}_config.yml"
-          if ! INPUT_DEPENDS="$2" nfpm_template > "$config_file"; then
-            printf "failed to executing nfpm_template for $1"
+          config_file="nfpm_${pkg_type}_config.yml"
+          if ! INPUT_DEPENDS="$deps" nfpm_template > "$config_file"; then
+            printf "failed to executing nfpm_template for $pkg_type"
             exit 1
           fi
           cat "$config_file"
-          nfpm package -f "$config_file" -p ${1} -t ./out/
+          nfpm package -f "$config_file" -p "$pkg_type" -t ./out/
         }
 
         package rpm "$INPUT_RPM_DEPENDS"

--- a/action.yml
+++ b/action.yml
@@ -73,11 +73,19 @@ inputs:
     default: ''
     required: false
   deb_depends:
-    description: 'Comma separated list of deb dependencies.'
+    description: 'Comma-separated list of deb dependencies.  These prerequistes are mandatory at package install-time.'
+    default: ''
+    required: false
+  deb_recommends:
+    description: 'Comma-separated list of deb packages recommended to also be installed.  These packages are optional at package install-time.'
     default: ''
     required: false
   rpm_depends:
-    description: 'Comma separated list of rpm dependencies.'
+    description: 'Comma-separated list of rpm dependencies.  These prerequistes are mandatory at package install-time.'
+    default: ''
+    required: false
+  rpm_recommends:
+    description: 'Comma-separated list of rpm packages recommended to also be installed.  These packages are optional at package install-time.'
     default: ''
     required: false
   preinstall:
@@ -223,7 +231,9 @@ runs:
         INPUT_POSTREMOVE: ${{ inputs.postremove }}
 
         INPUT_DEB_DEPENDS: ${{ inputs.deb_depends }}
+        INPUT_DEB_RECOMMENDS: ${{ inputs.deb_recommends }}
         INPUT_RPM_DEPENDS: ${{ inputs.rpm_depends }}
+        INPUT_RPM_RECOMMENDS: ${{ inputs.rpm_recommends }}
       run: |
         if ! fileo=$(file "$INPUT_BINARY"); then
           printf "could not find binary: $(pwd)\n$(ls)"
@@ -234,10 +244,10 @@ runs:
 
         mkdir -p ./out
 
-        package() { local pkg_type="$1" deps="${2:-}"
+        package() { local pkg_type="$1" deps="${2:-}" recs="${3:-}"
           local config_file
           config_file="nfpm_${pkg_type}_config.yml"
-          if ! INPUT_DEPENDS="$deps" nfpm_template > "$config_file"; then
+          if ! INPUT_DEPENDS="$deps" INPUT_RECOMMENDS="$recs" nfpm_template > "$config_file"; then
             printf "failed to executing nfpm_template for $pkg_type"
             exit 1
           fi

--- a/action.yml
+++ b/action.yml
@@ -236,10 +236,11 @@ runs:
         INPUT_RPM_RECOMMENDS: ${{ inputs.rpm_recommends }}
       run: |
         if ! fileo=$(file "$INPUT_BINARY"); then
-          printf "could not find binary: $(pwd)\n$(ls)"
+          printf "could not find binary: %s\n" "$(pwd)"
+          ls
           exit 1
         else
-          printf "packaging binary %s" "$fileo"
+          printf "packaging binary %s\n" "$fileo"
         fi
 
         mkdir -p ./out
@@ -248,7 +249,7 @@ runs:
           local config_file
           config_file="nfpm_${pkg_type}_config.yml"
           if ! INPUT_DEPENDS="$deps" INPUT_RECOMMENDS="$recs" nfpm_template > "$config_file"; then
-            printf "failed to executing nfpm_template for $pkg_type"
+            printf "failed to executing nfpm_template for %s\n" "$pkg_type"
             exit 1
           fi
           cat "$config_file"

--- a/fpm_template.go
+++ b/fpm_template.go
@@ -21,6 +21,7 @@ type NfpmInput struct {
 	Homepage        string
 	License         string
 	Depends         []string
+	Recommends      []string
 	Binary          string
 	BinaryDest      string
 	Preinstall      string
@@ -86,6 +87,7 @@ func main() {
 	inputHomepage := os.Getenv("INPUT_HOMEPAGE")
 	inputLicense := os.Getenv("INPUT_LICENSE")
 	inputDepends := os.Getenv("INPUT_DEPENDS")
+	inputRecommends := os.Getenv("INPUT_RECOMMENDS")
 	inputBinary := os.Getenv("INPUT_BINARY")
 	inputBinPath := os.Getenv("INPUT_BIN_PATH")
 	inputConfigDir := os.Getenv("INPUT_CONFIG_DIR")
@@ -100,6 +102,10 @@ func main() {
 	depends := strings.Split(inputDepends, ",")
 	if inputDepends == "" {
 		depends = []string{}
+	}
+	recommends := strings.Split(inputRecommends, ",")
+	if inputRecommends == "" {
+		recommends = []string{}
 	}
 	binName := filepath.Base(inputBinary)
 	binDest := filepath.Join(inputBinPath, binName)
@@ -124,6 +130,7 @@ func main() {
 		Homepage:        inputHomepage,
 		License:         inputLicense,
 		Depends:         depends,
+		Recommends:      recommends,
 		Binary:          inputBinary,
 		BinaryDest:      binDest,
 		Preinstall:      inputPreinstall,
@@ -158,6 +165,12 @@ homepage: {{ .Homepage }}
 license: {{ .License }}
 depends:
 {{- with .Depends }}
+{{- range $index, $element := . }}
+  - {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Recommends }}
+recommends:
 {{- range $index, $element := . }}
   - {{ . }}
 {{- end }}


### PR DESCRIPTION
This PR adds support for specifying recommended packages (request in [NET-10747](https://hashicorp.atlassian.net/browse/NET-10747)).

The test workflow has been updated to pass required and recommended dependencies, both can now be verified in the [generated templates](https://github.com/hashicorp/actions-packaging-linux/actions/runs/10782363137/job/29902185802#step:6:249) as well as in the package examination [output](https://github.com/hashicorp/actions-packaging-linux/actions/runs/10782363137/job/29902185802#step:9:21).

Further, the generated packages are [uploaded](https://github.com/hashicorp/actions-packaging-linux/actions/runs/10782363137/job/29902185802#step:7:1) to the workflow run to facilitate local inspection.

[NET-10747]: https://hashicorp.atlassian.net/browse/NET-10747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ