### PR TITLE
Update internal github action workflows to avoid the Node 20 deprecation

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,11 @@ jobs:
           - true
           - false
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: build
       - if: matrix.go_toolchain_preinstalled == true
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           go-version-file: build/go.mod
@@ -28,7 +28,7 @@ jobs:
           go build -o template .
           echo "binary-path=build/template" | tee -a "$GITHUB_OUTPUT"
           ls -la
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: action
       - uses: ./action
@@ -50,7 +50,7 @@ jobs:
           deb_depends: bash
           deb_recommends: dmidecode
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.go_toolchain_preinstalled == true # only need one set of artifacts
         with:
           name: artifacts

--- a/action.yml
+++ b/action.yml
@@ -125,7 +125,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         path: nfpm_packaging
         repository: hashicorp/actions-packaging-linux
@@ -190,7 +190,7 @@ runs:
         fi
         echo "is_installed=${go_installed}" | tee -a "$GITHUB_OUTPUT"
     - if: steps.check_go.is_installed == 'false'
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         cache: false
         go-version-file: go.mod


### PR DESCRIPTION
## PCI review checklist

Updated internal github action workflows to avoid the Node 20 deprecation warning



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
